### PR TITLE
Document that error is thrown when sheet is closed

### DIFF
--- a/website/docs/share-single.mdx
+++ b/website/docs/share-single.mdx
@@ -41,6 +41,16 @@ Or with `async/await`:
   }
 ```
 
+*Note that in the case of a user closing the share sheet without sharing, an error will be thrown. It is up to you to handle this error, i.e.:
+
+```js
+   try {
+       const shareResponse = await Share.shareSingle(shareOptions);
+   } catch (error) {
+       // handle error
+   }
+```
+
 ## Supported Options
 
 You can pass the option that will be handled by the native code, similar to `Share.open`.


### PR DESCRIPTION
As the title states, this small doc change would have saved me from the issue I raised in https://github.com/react-native-share/react-native-share/issues/1291

Totally flexible about the wording or arrangement, I think it's just important to mention somewhere in the docs that closing the sheet throws an error.

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
